### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
                 <configuration>
                     <target>1.6</target>
                     <source>1.6</source>
+                    <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Set UTF-8 encoding to compiler to fix build failure. I had this error building in a non-English environment.
